### PR TITLE
Setup Vite build configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AISpace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/index.ts"></script>
+  </body>
+</html>

--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,3 @@
-export { default as AISpaceApp } from './App';
-export * from './routes';
-export * from './components';
-export * from './hooks';
-export * from './services';
+import './src/index.ts';
 
-export const getAISpaceBasePath = () =>
-  (import.meta.env?.VITE_AISPACE_BASE as string | undefined) ?? '/admin/ai-developer';
-
-export const AISPACE_BASE_PATH = getAISpaceBasePath();
-
+export * from './src/index.ts';

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 4173",
     "deploy": "firebase deploy --only hosting"
   },
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { AIDeveloperRoute, GurulaRoute, SecretsRoute } from './routes';
+import { AIDeveloperRoute, GurulaRoute, SecretsRoute } from '@aispace/routes';
 
 const AISpaceApp = () => {
   return (
@@ -18,4 +18,3 @@ const AISpaceApp = () => {
 };
 
 export default AISpaceApp;
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,23 @@
+import { createElement } from 'react';
+import ReactDOM from 'react-dom/client';
+
+import AISpaceApp from './App';
+
+export { default as AISpaceApp } from './App';
+export * from '@aispace/routes';
+export * from '@aispace/components';
+export * from '@aispace/hooks';
+export * from '@aispace/services';
+
+export const getAISpaceBasePath = () =>
+  (import.meta.env?.VITE_AISPACE_BASE as string | undefined) ?? '/admin/ai-developer';
+
+export const AISPACE_BASE_PATH = getAISpaceBasePath();
+
+if (typeof document !== 'undefined') {
+  const rootElement = document.getElementById('root');
+
+  if (rootElement) {
+    ReactDOM.createRoot(rootElement).render(createElement(AISpaceApp));
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "baseUrl": ".",
+    "paths": {
+      "@aispace/*": ["./*"]
+    },
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./node_modules/.tmp/tsc/app"
+  },
+  "include": [
+    "src",
+    "components",
+    "hooks",
+    "routes",
+    "services",
+    "store",
+    "theme",
+    "types",
+    "index.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@aispace/*": ["./*"]
+    }
+  },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "baseUrl": ".",
+    "paths": {
+      "@aispace/*": ["./*"]
+    },
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@aispace': path.resolve(__dirname, './'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Vite configuration and HTML entry shell required for Vite hosting
- move the app entry into `src` and re-export existing modules for compatibility
- configure TypeScript project references and scripts so Firebase hosting can build with Vite

## Testing
- Not run (npm registry returned 403 during installation)


------
https://chatgpt.com/codex/tasks/task_e_68e689b3b36083318e4b969d023b2c29